### PR TITLE
For UPS tracking numbers, added a mod 10 checkdigit check.

### DIFF
--- a/lib/shipmethod.js
+++ b/lib/shipmethod.js
@@ -2,7 +2,41 @@ function ShipMethod() {
 
 }
 
+ShipMethod.confirmUps = function(track) {
+  var sum = 0;
+  for (var index=2; index<17; index++) {
+    var num = 0;
+    var asciiValue = track[index].charCodeAt(0);
+
+    if (asciiValue>=48 && asciiValue<=57) {
+      num = parseInt(track[index], 10)
+    }
+    else {
+      num = (asciiValue - 63) % 10
+    }
+
+    if (index % 2 == 0) {
+      sum += num;
+    }
+    else {
+      sum += (num * 2);
+    }
+  }
+
+  var checkdigit = 0;
+  if ((sum % 10) > 0) {
+    checkdigit = 10 - sum % 10;
+  }
+
+  if (checkdigit == parseInt(track[17], 10)) {
+    return true;
+  }
+
+  return false;
+};
+
 ShipMethod.prototype = {
+
   getCarrier: function(track) {
 
     var carrier;
@@ -12,7 +46,8 @@ ShipMethod.prototype = {
       var carriers = [
         {
           name: 'UPS',
-          regex: /^1Z[0-9A-Z]{16}$/i
+          regex: /^1Z[0-9A-Z]{16}$/i,
+          confirm: ShipMethod.confirmUps
         },
         {
           name: 'UPS',
@@ -47,8 +82,15 @@ ShipMethod.prototype = {
 
       carriers.every(function(c) {
         if(track.match(c.regex)) {
-         carrier = c.name;
-         return false;
+         if(c.confirm) {
+          if (c.confirm(track)) {
+           carrier = c.name;
+           return false;
+          }
+         } else {
+          carrier = c.name;
+          return false;
+         }
         } else {
           return true;
         }

--- a/test/shipmethod.js
+++ b/test/shipmethod.js
@@ -12,6 +12,7 @@ var fixtures = [
   { carrier: 'USPS', number: '7000 0000 0000 0000 0000' },
   { carrier: 'USPS', number: '2300 0000 0000 0000 0000' },
   { carrier: 'UPS', number: '1Z 999 AA1 01 2345 6784' },
+  { carrier: undefined, number: '1Z 4WX 950 03 0419 6569' },
   { carrier: 'FedEx', number: '817456723444' },
   { carrier: 'FedEx', number: '817456723444222' },
   { carrier: 'USPS', number: 'LJ893369662US' },


### PR DESCRIPTION
Based on [this](http://answers.google.com/answers/threadview/id/207899.html), it appears that UPS tracking numbers aren't simply 18 characters long and begin with `1Z`.  There's a mod-10 check-digit which should be confirmed. This PR adds a `confirm` function, which, when present, must return true if the tracking number is truly legitimate.
